### PR TITLE
The Ruby standard library logger always returns true.

### DIFF
--- a/lib/hedgelog.rb
+++ b/lib/hedgelog.rb
@@ -127,6 +127,7 @@ class Hedgelog
     data = extract_top_level_keys(data)
 
     @logdev.write(Yajl::Encoder.encode(data) + "\n")
+    true
   end
 
   def default_data(severity)


### PR DESCRIPTION
This can be seen here: https://github.com/ruby/ruby/blob/ruby_2_3/lib/logger.rb#L433-L435

This commit makes hedgelog behave the same