### PR TITLE
Added formatter= method to better match ruby's generic logger methods

### DIFF
--- a/lib/hedgelog.rb
+++ b/lib/hedgelog.rb
@@ -118,6 +118,10 @@ class Hedgelog
     ::Logger::Formatter.new
   end
 
+  def formatter=(_)
+    formatter
+  end
+
   private
 
   def level_to_int(level)

--- a/lib/hedgelog/version.rb
+++ b/lib/hedgelog/version.rb
@@ -1,4 +1,4 @@
 # frozen_string_literal: true
 class Hedgelog
-  VERSION = '0.1.8'.freeze
+  VERSION = '0.1.9'.freeze
 end


### PR DESCRIPTION
Resque was trying to set it and blowing up.